### PR TITLE
Laravel 12 & PHP 8.4 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [8.2, 8.3]
-                test-bench: [^8.0, ^9.0]
+                php: [8.4]
+                test-bench: [^10.0]
 
         runs-on: packages
         container: chialab/php:${{ matrix.php }}
@@ -43,7 +43,7 @@ jobs:
     php-cs-fixer:
         name: php-cs-fixer
         runs-on: packages
-        container: chialab/php:8.3
+        container: chialab/php:8.4
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -79,8 +79,8 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [8.2, 8.3]
-                test-bench: [^8.0, ^9.0]
+                php: [8.4]
+                test-bench: [^10.0]
 
         runs-on: packages
         container: chialab/php:${{ matrix.php }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
 
             - name: Composer cache
               uses: actions/cache@v4
+              if: ${{ !env.ACT }}
               with:
                   path: vendor
                   key: composer-${{ hashFiles('composer.json') }}
@@ -50,6 +51,7 @@ jobs:
 
             - name: Composer cache
               uses: actions/cache@v4
+              if: ${{ !env.ACT }}
               with:
                   path: vendor
                   key: composer-${{ hashFiles('composer.json') }}
@@ -90,6 +92,7 @@ jobs:
 
             - name: Composer cache
               uses: actions/cache@v4
+              if: ${{ !env.ACT }}
               with:
                   path: vendor
                   key: composer-${{ hashFiles('composer.json') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 Here are some of the commands that you'll need:
 
--   install dependencies: `docker run -it --rm -v $PWD:/app -w /app chialab/php-dev:8.2 composer install`
--   run tests with phpunit: `docker run -it --rm -v $PWD:/app -w /app chialab/php-dev:8.2 composer test`
--   reformat using php-cs-fixer: `docker run -it --rm -v $PWD:/app -w /app chialab/php-dev:8.2 composer cs-fix`
--   reformat the rest with prettier: `docker run -it --rm -v $PWD:/app -w /app tmknom/prettier --write .`
--   analyse with phpstan: `docker run -it --rm -v $PWD:/app -w /app chialab/php-dev:8.2 composer phpstan`
+- install dependencies: `docker run -it --rm -v $PWD:/app -w /app chialab/php-dev:8.4 composer install`
+- run tests with phpunit: `docker run -it --rm -v $PWD:/app -w /app chialab/php-dev:8.4 composer test`
+- reformat using php-cs-fixer: `docker run -it --rm -v $PWD:/app -w /app chialab/php-dev:8.4 composer cs-fix`
+- reformat the rest with prettier: `docker run -it --rm -v $PWD:/app -w /app tmknom/prettier --write .`
+- analyse with phpstan: `docker run -it --rm -v $PWD:/app -w /app chialab/php-dev:8.4 composer phpstan`

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
 		"illuminate/contracts": "^12.0"
 	},
 	"require-dev": {
+		"pestphp/pest": "^3.8",
 		"php-cs-fixer/shim": "^3.75",
 		"tenantcloud/php-cs-fixer-rule-sets": "^3.4.1",
 		"phpstan/phpstan": "^2.1.17",
@@ -27,8 +28,8 @@
 		}
 	},
 	"scripts": {
-		"test": "vendor/bin/phpunit",
-		"coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html coverage",
+		"test": "vendor/bin/pest",
+		"coverage": "XDEBUG_MODE=coverage vendor/bin/pest --coverage-html coverage",
 		"cs-fix": "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix -v --show-progress=dots",
 		"phpstan": "vendor/bin/phpstan analyse --memory-limit=2G",
 		"testbench": "vendor/bin/testbench"

--- a/composer.json
+++ b/composer.json
@@ -3,19 +3,18 @@
 	"description": "Skeleton for Laravel packages",
 	"license": "MIT",
 	"require": {
-		"php": ">=8.2",
-		"illuminate/contracts": "^10.0|^11.0"
+		"php": ">=8.4",
+		"illuminate/contracts": "^12.0"
 	},
 	"require-dev": {
-		"pestphp/pest": "^2.8",
-		"php-cs-fixer/shim": "^3.54",
-		"tenantcloud/php-cs-fixer-rule-sets": "~3.3.1",
-		"phpstan/phpstan": "~1.10.21",
-		"phpstan/phpstan-phpunit": "^1.3",
-		"phpstan/phpstan-webmozart-assert": "^1.2",
-		"phpstan/phpstan-mockery": "^1.1",
-		"nunomaduro/larastan": "^2.6",
-		"orchestra/testbench": "^8.5|^9.0"
+		"php-cs-fixer/shim": "^3.75",
+		"tenantcloud/php-cs-fixer-rule-sets": "^3.4.1",
+		"phpstan/phpstan": "^2.1.17",
+		"phpstan/phpstan-phpunit": "^2.0",
+		"phpstan/phpstan-webmozart-assert": "^2.0",
+		"phpstan/phpstan-mockery": "^2.0",
+		"nunomaduro/larastan": "^3.0",
+		"orchestra/testbench": "^10.0"
 	},
 	"autoload": {
 		"psr-4": {
@@ -28,9 +27,9 @@
 		}
 	},
 	"scripts": {
-		"test": "vendor/bin/pest",
-		"coverage": "XDEBUG_MODE=coverage vendor/bin/pest --coverage-html coverage",
-		"cs-fix": "vendor/bin/php-cs-fixer fix -v --show-progress=dots",
+		"test": "vendor/bin/phpunit",
+		"coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html coverage",
+		"cs-fix": "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix -v --show-progress=dots",
 		"phpstan": "vendor/bin/phpstan analyse --memory-limit=2G",
 		"testbench": "vendor/bin/testbench"
 	},

--- a/src/Example.php
+++ b/src/Example.php
@@ -2,6 +2,4 @@
 
 namespace TenantCloud\Skeleton;
 
-class Example
-{
-}
+class Example {}

--- a/src/SkeletonServiceProvider.php
+++ b/src/SkeletonServiceProvider.php
@@ -4,6 +4,4 @@ namespace TenantCloud\Skeleton;
 
 use Illuminate\Support\ServiceProvider;
 
-class SkeletonServiceProvider extends ServiceProvider
-{
-}
+class SkeletonServiceProvider extends ServiceProvider {}

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,7 +1,15 @@
 <?php
 
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
 use TenantCloud\Skeleton\Example;
 
-test('something works', function () {
-	expect(new Example())->not->toBeNull();
-});
+class ExampleTest extends TestCase
+{
+	public function testSomethingWorks(): void
+	{
+		/* @phpstan-ignore-next-line */
+		$this->assertNotNull(new Example());
+	}
+}


### PR DESCRIPTION
BREAKING CHANGE: Requires Laravel 12 and PHP 8.4+. Support for older Laravel versions and PHP <8.4 dropped.